### PR TITLE
Kan 10  member jgone2 - Member Entity 및 CRUD 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// MapStruct
-	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
-	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -54,6 +54,9 @@ dependencies {
 
 	// servlet
 	implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
+
+	// javax
+	implementation 'javax.validation:validation-api:2.0.1.Final'
 
 	// jakarta
 	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'

--- a/src/main/java/com/volumeTest/volume/common/audit/Auditable.java
+++ b/src/main/java/com/volumeTest/volume/common/audit/Auditable.java
@@ -1,0 +1,22 @@
+package com.volumeTest.volume.common.audit;
+
+
+import jakarta.persistence.Column;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import java.time.LocalDateTime;
+
+public abstract class Auditable {
+  @CreatedDate
+  @Setter(lombok.AccessLevel.NONE)
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime modifiedAt;
+
+  public Auditable() {
+  }
+}

--- a/src/main/java/com/volumeTest/volume/common/exception/codeEnum/ExceptionCode.java
+++ b/src/main/java/com/volumeTest/volume/common/exception/codeEnum/ExceptionCode.java
@@ -1,0 +1,29 @@
+package com.volumeTest.volume.common.exception.codeEnum;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionCode {
+
+  // Member
+  MEMBER_NOT_FOUND(404, 10001, "사용자를 찾을 수 없습니다."),
+  MEMBER_EXISTS(409, 10002, "이미 존재하는 사용자입니다."),
+  MEMBER_LOGIN_ID_EXISTS(409, 10003, "이미 존재하는 아이디 입니다."),
+  MEMBER_EMAIL_EXISTS(409, 10004, "이미 존재하는 Email 입니다."),
+  MEMBER_PHONE_NUM_EXISTS(409, 10005, "이미 존재하는 휴대폰 번호 입니다."),
+
+  // Verify
+  MEMBER_PASSWORD_MISMATCH(409, 10201, "비밀번호가 일치하지 않습니다."),
+  MEMBER_PASSWORD_NOT_CHANGE(409, 10202, "기존의 비밀번호와 같습니다. 비밀번호가 변경되지 않았습니다."),
+
+  // Login
+  BAD_CREDENTIALS(401, 10301, "아이디 또는 비밀번호가 일치하지 않습니다."),
+  AUTHENTICATION_CREDENTIALS_NOT_FOUND(401, 10302, "인증 정보가 없습니다."),
+  UNKNOWN_LOGIN_FAIL(401, 10302, "알 수 없는 로그인 오류입니다.");
+
+  private final int status;
+  private final int customCode;
+  private final String message;
+}

--- a/src/main/java/com/volumeTest/volume/common/exception/codeEnum/ExceptionCode.java
+++ b/src/main/java/com/volumeTest/volume/common/exception/codeEnum/ExceptionCode.java
@@ -10,9 +10,7 @@ public enum ExceptionCode {
   // Member
   MEMBER_NOT_FOUND(404, 10001, "사용자를 찾을 수 없습니다."),
   MEMBER_EXISTS(409, 10002, "이미 존재하는 사용자입니다."),
-  MEMBER_LOGIN_ID_EXISTS(409, 10003, "이미 존재하는 아이디 입니다."),
-  MEMBER_EMAIL_EXISTS(409, 10004, "이미 존재하는 Email 입니다."),
-  MEMBER_PHONE_NUM_EXISTS(409, 10005, "이미 존재하는 휴대폰 번호 입니다."),
+  MEMBER_EMAIL_EXISTS(409, 10003, "이미 존재하는 Email 입니다."),
 
   // Verify
   MEMBER_PASSWORD_MISMATCH(409, 10201, "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Email.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Email.java
@@ -1,2 +1,27 @@
-package com.volumeTest.volume.common.pattern.custom.member;public interface Email {
+package com.volumeTest.volume.common.pattern.custom.member;
+
+import com.volumeTest.volume.common.pattern.customValidation.member.EmailValidatior;
+
+import javax.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = EmailValidatior.class)
+@Documented
+public @interface Email {
+
+  String message() default "이메일 요구사항을 만족하지 않습니다.";
+  String patternMessage() default "이메일 형식이 올바르지 않습니다.";
+  String lengthMessage() default "이메일은 {minLength}~{maxLength}자 사이여야 합니다.";
+  Class[] groups() default {};
+  Class[] payload() default {};
+
+  int minLength() default 6; // 이메일 최소길이
+  int maxLength() default 30; // 이메일 최대길이
 }

--- a/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Email.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Email.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.common.pattern.custom.member;public interface Email {
+}

--- a/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Name.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Name.java
@@ -1,2 +1,26 @@
-package com.volumeTest.volume.common.pattern.custom.member;public interface Name {
+package com.volumeTest.volume.common.pattern.custom.member;
+
+import com.volumeTest.volume.common.pattern.customValidation.member.NameValidator;
+
+import javax.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = NameValidator.class)
+@Documented
+public @interface Name {
+
+  String message() default "이름 요구사항을 만족하지 않습니다.";
+  String lengthMessage() default "이름은 {minLength}~{maxLength}자 사이여야 합니다.";
+  Class[] groups() default {};
+  Class[] payload() default {};
+
+  int minLength() default 1; // 이름 최소길이
+  int maxLength() default 20; // 이름 최대길이
 }

--- a/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Name.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Name.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.common.pattern.custom.member;public interface Name {
+}

--- a/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Password.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Password.java
@@ -1,2 +1,27 @@
-package com.volumeTest.volume.common.pattern.custom.member;public interface Password {
+package com.volumeTest.volume.common.pattern.custom.member;
+
+import com.volumeTest.volume.common.pattern.customValidation.member.PasswordValidator;
+
+import javax.validation.Constraint;
+
+import java.lang.annotation.*;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = PasswordValidator.class)
+@Documented
+public @interface Password {
+
+  String message() default "비밀번호 요구사항을 만족하지 않습니다.";
+  String patternMessage() default "비밀번호는 영문 대/소문자, 숫자, 키패드 1~0까지의 특수문자만 가능하며 각각 한 글자 이상이 포함되어야 합니다.";
+  String lengthMessage() default "비밀번호는 {minLength}~{maxLength}자 사이여야 합니다.";
+  Class[] groups() default {};
+  Class[] payload() default {};
+
+
+  int minLength() default 8; // 비밀번호 최소길이
+  int maxLength() default 20; // 비밀번호 최대길이
 }

--- a/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Password.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/custom/member/Password.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.common.pattern.custom.member;public interface Password {
+}

--- a/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/EmailValidatior.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/EmailValidatior.java
@@ -1,0 +1,58 @@
+package com.volumeTest.volume.common.pattern.customValidation.member;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EmailValidator implements ConstraintValidator<Email, String> {
+
+  // 이메일 정규표현식(https://emailregex.com/)
+  private static final String EMAIL_PATTERN =
+          "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+" +
+                  "(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"" +
+                  "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")" +
+                  "@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+" +
+                  "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.)" +
+                  "{3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:" +
+                  "(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])";
+
+  // 이메일 최소, 최대길이
+  private int minLength;
+  private int maxLength;
+
+  // 이메일 요구사항을 만족하지 않을 경우 출력할 메시지
+  private String message;
+  private String patternMessage;
+  private String lengthMessage;
+  @Override
+  public void initialize(Email constraintAnnotation) {
+    this.minLength = constraintAnnotation.minLength();
+    this.maxLength = constraintAnnotation.maxLength();
+    this.message = constraintAnnotation.message();
+    this.patternMessage = constraintAnnotation.patternMessage();
+    this.lengthMessage = constraintAnnotation.lengthMessage();
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) return false;
+
+    int length = value.length();
+    boolean patternMatch = value.matches(EMAIL_PATTERN);
+
+    if (length < this.minLength || length > this.maxLength || !patternMatch) {
+      context.disableDefaultConstraintViolation();  // 기본 제약 조건을 비활성화.
+
+      // 만약 길이 조건을 충족하지 않았다면 lengthMessage를 출력.
+      if (length < this.minLength || length > this.maxLength) {
+        context.buildConstraintViolationWithTemplate(lengthMessage).addConstraintViolation();
+      }
+
+      // 만약 패턴 조건을 충족하지 않았다면 patternMessage를 출력.
+      if (!patternMatch) {
+        context.buildConstraintViolationWithTemplate(patternMessage).addConstraintViolation();
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/EmailValidatior.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/EmailValidatior.java
@@ -1,9 +1,11 @@
 package com.volumeTest.volume.common.pattern.customValidation.member;
 
+import com.volumeTest.volume.common.pattern.custom.member.Email;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
-public class EmailValidator implements ConstraintValidator<Email, String> {
+public class EmailValidatior implements ConstraintValidator<Email, String> {
 
   // 이메일 정규표현식(https://emailregex.com/)
   private static final String EMAIL_PATTERN =

--- a/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/NameValidator.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/NameValidator.java
@@ -1,2 +1,39 @@
-package com.volumeTest.volume.common.pattern.customValidation.member;public class NameValidator {
+package com.volumeTest.volume.common.pattern.customValidation.member;
+
+import com.volumeTest.volume.common.pattern.custom.member.Name;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NameValidator implements ConstraintValidator<Name, String> {
+
+  // 이름 최소, 최대길이
+  private int minLength;
+  private int maxLength;
+
+  // 이름 요구사항을 만족하지 않을 경우 출력할 메시지
+  private String message;
+  private String lengthMessage;
+
+  @Override
+  public void initialize(Name constraintAnnotation) {
+    this.minLength = constraintAnnotation.minLength();
+    this.maxLength = constraintAnnotation.maxLength();
+    this.message = constraintAnnotation.message();
+    this.lengthMessage = constraintAnnotation.lengthMessage();
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) return false;
+
+    int length = value.length();
+
+    if (length < this.minLength || length > this.maxLength) {
+      context.disableDefaultConstraintViolation();  // 기본 제약 조건을 비활성화.
+      context.buildConstraintViolationWithTemplate(lengthMessage).addConstraintViolation(); // 만약 길이 조건을 충족하지 않았다면 lengthMessage를 출력.
+    }
+
+    return true;
+  }
 }

--- a/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/NameValidator.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/NameValidator.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.common.pattern.customValidation.member;public class NameValidator {
+}

--- a/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/PasswordValidator.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/PasswordValidator.java
@@ -1,2 +1,61 @@
-package com.volumeTest.volume.common.pattern.customValidation.member;public class PasswordValidator {
+package com.volumeTest.volume.common.pattern.customValidation.member;
+
+import com.volumeTest.volume.common.pattern.custom.member.Password;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+
+
+public class PasswordValidator implements ConstraintValidator<Password, String> {
+
+  // 비밀번호 정규식(영문 대/소문자, 숫자, 키패드 1~0까지의 특수문자만 가능하며 각각 한 글자 이상이 포함되어야 함)
+  private static final Pattern PASSWORD_PATTERN =
+          Pattern.compile("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()])[a-z0-9!@#$%^&*()]+$");
+
+  // 비밀번호 최소, 최대길이
+  private int minLength;
+  private int maxLength;
+
+  // 비밀번호 요구사항을 만족하지 않을 경우 출력할 메시지
+  private String message;
+  private String patternMessage;
+  private String lengthMessage;
+
+  @Override
+  public void initialize(Password constraintAnnotation) {
+    this.minLength = constraintAnnotation.minLength();
+    this.maxLength = constraintAnnotation.maxLength();
+    this.message = constraintAnnotation.message();
+    this.patternMessage = constraintAnnotation.patternMessage();
+    this.lengthMessage = constraintAnnotation.lengthMessage();
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    if (value == null) {
+      return false;
+    }
+
+    int length = value.length();
+    boolean patternMatch = PASSWORD_PATTERN.matcher(value).matches();
+
+    if (length < minLength || length > maxLength || !patternMatch) {
+      context.disableDefaultConstraintViolation(); // 기본 제약 조건을 비활성화.
+
+      // 만약 길이 조건을 충족하지 않았다면 lengthMessage를 출력.
+      if (length < minLength) {
+        context.buildConstraintViolationWithTemplate(lengthMessage).addConstraintViolation();
+      }
+
+      // 만약 길이 조건을 충족하지 않았다면 patternMessage를 출력.
+      if (!patternMatch) {
+        context.buildConstraintViolationWithTemplate(patternMessage).addConstraintViolation();
+      }
+
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/PasswordValidator.java
+++ b/src/main/java/com/volumeTest/volume/common/pattern/customValidation/member/PasswordValidator.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.common.pattern.customValidation.member;public class PasswordValidator {
+}

--- a/src/main/java/com/volumeTest/volume/member/Controller/MemberController.java
+++ b/src/main/java/com/volumeTest/volume/member/Controller/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController {
                                     @Valid @RequestBody MemberDto.Patch memberPatchDto) {
 
     Member findMember = memberService.findMemberByEmail(email);
-    Member updateMember = memberService.updateMember(findMember, memberPatchDto.getPassword());
+    Member updateMember = memberService.updateMember(findMember, memberPatchDto.getName(), memberPatchDto.getPassword());
 
     return ResponseEntity.ok(mapper.memberToMemberPatchResponseDto(updateMember));
   }

--- a/src/main/java/com/volumeTest/volume/member/Controller/MemberController.java
+++ b/src/main/java/com/volumeTest/volume/member/Controller/MemberController.java
@@ -1,2 +1,65 @@
-package com.volumeTest.volume.member.Controller;public class MemberController {
+package com.volumeTest.volume.member.Controller;
+
+import com.volumeTest.volume.member.dto.MemberDto;
+import com.volumeTest.volume.member.entity.Member;
+import com.volumeTest.volume.member.mapper.MemberMapper;
+import com.volumeTest.volume.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/member")
+public class MemberController {
+
+  MemberService memberService;
+  MemberMapper mapper;
+
+  // 회원 가입
+  @PostMapping("/signup")
+  public ResponseEntity postMember(@RequestBody @Valid MemberDto.Post memberPostDto) {
+
+    Member member = mapper.memberPostDtoToMember(memberPostDto);
+    memberService.createMember(member);
+
+    return new ResponseEntity<>(HttpStatus.CREATED);
+  }
+
+  // 회원조회
+  @GetMapping("/info")
+  public ResponseEntity getMember(@AuthenticationPrincipal String email) {
+
+    Member findMember = memberService.findMemberByEmail(email);
+
+
+    return ResponseEntity.ok(mapper.memberToMemberPostResponseDto(findMember));
+  }
+
+  // 회원정보 수정
+  @PatchMapping("/mypage/update")
+  public ResponseEntity patchMember(@AuthenticationPrincipal String email,
+                                    @Valid @RequestBody MemberDto.Patch memberPatchDto) {
+
+    Member findMember = memberService.findMemberByEmail(email);
+    Member updateMember = memberService.updateMember(findMember, memberPatchDto.getPassword());
+
+    return ResponseEntity.ok(mapper.memberToMemberPatchResponseDto(updateMember));
+  }
+
+  // 회원탈퇴
+  @DeleteMapping("/mypage/delete")
+  public ResponseEntity deleteMember(@AuthenticationPrincipal String email,
+                                        @Valid  @RequestBody MemberDto.CheckPassword checkPasswordDto) {
+
+    Member findMember = memberService.findMemberByEmail(email);
+    memberService.deleteMember(findMember, checkPasswordDto.getPassword());
+
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/volumeTest/volume/member/Controller/MemberController.java
+++ b/src/main/java/com/volumeTest/volume/member/Controller/MemberController.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.member.Controller;public class MemberController {
+}

--- a/src/main/java/com/volumeTest/volume/member/Dto/MemberDto.java
+++ b/src/main/java/com/volumeTest/volume/member/Dto/MemberDto.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.member.Dto;public class MemberDto {
+}

--- a/src/main/java/com/volumeTest/volume/member/Dto/MemberDto.java
+++ b/src/main/java/com/volumeTest/volume/member/Dto/MemberDto.java
@@ -1,2 +1,98 @@
-package com.volumeTest.volume.member.Dto;public class MemberDto {
-}
+package com.volumeTest.volume.member.Dto;
+
+import com.volumeTest.volume.common.pattern.custom.member.Email;
+import com.volumeTest.volume.common.pattern.custom.member.Name;
+import com.volumeTest.volume.common.pattern.custom.member.Password;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class MemberDto {
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class Login {
+
+    @Email
+    private String email;
+    @Password
+    private String password;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class Post {
+
+      @Email
+      private String email;
+      @Password
+      private String password;
+      @Name
+      private String name;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class Patch {
+
+      @Password
+      private String password;
+      @Name
+      private String name;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    public static class CheckPassword {
+      @Password
+      private String password;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public abstract static class MemberResponse {
+
+      private int  memberId;
+      @Email
+      private String email;
+      @Password
+      private String password;
+      @Name
+      private String name;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberPostResponse extends MemberResponse {
+      private LocalDateTime createdAt;
+
+      public MemberPostResponse(int memberId, String email, String password, String name, LocalDateTime createdAt) {;
+        this.createdAt = createdAt;
+      }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberPatchResponse extends MemberResponse {
+      private LocalDateTime modifiedAt;
+
+      public MemberPatchResponse(int memberId, String email, String password, String name, LocalDateTime modifiedAt) {
+        super(memberId, email, password, name);
+        this.modifiedAt = modifiedAt;
+      }
+    }
+
+  }

--- a/src/main/java/com/volumeTest/volume/member/Entity/Member.java
+++ b/src/main/java/com/volumeTest/volume/member/Entity/Member.java
@@ -1,2 +1,27 @@
-package com.volumeTest.volume.member.Entity;public class Member {
+package com.volumeTest.volume.member.Entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "MEMBERS")
+public class Member {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int memberId;
+
+  @Column(nullable = false, unique = true, updatable = false, length = 30)
+  private String email;
+
+  @Column(nullable = false, unique = false, updatable = true, length = 20)
+  private String password;
+
+  @Column(nullable = false, unique = false, updatable = true, length = 20)
+  private String name;
 }

--- a/src/main/java/com/volumeTest/volume/member/dto/MemberDto.java
+++ b/src/main/java/com/volumeTest/volume/member/dto/MemberDto.java
@@ -1,4 +1,4 @@
-package com.volumeTest.volume.member.Dto;
+package com.volumeTest.volume.member.dto;
 
 import com.volumeTest.volume.common.pattern.custom.member.Email;
 import com.volumeTest.volume.common.pattern.custom.member.Name;

--- a/src/main/java/com/volumeTest/volume/member/dto/MemberDto.java
+++ b/src/main/java/com/volumeTest/volume/member/dto/MemberDto.java
@@ -56,7 +56,6 @@ public class MemberDto {
       private String password;
     }
 
-    @Builder
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
@@ -71,7 +70,6 @@ public class MemberDto {
       private String name;
     }
 
-    @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/com/volumeTest/volume/member/entity/Member.java
+++ b/src/main/java/com/volumeTest/volume/member/entity/Member.java
@@ -1,4 +1,4 @@
-package com.volumeTest.volume.member.Entity;
+package com.volumeTest.volume.member.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/volumeTest/volume/member/entity/Member.java
+++ b/src/main/java/com/volumeTest/volume/member/entity/Member.java
@@ -19,7 +19,7 @@ public class Member {
   @Column(nullable = false, unique = true, updatable = false, length = 30)
   private String email;
 
-  @Column(nullable = false, unique = false, updatable = true, length = 20)
+  @Column(nullable = false, unique = false, updatable = true)
   private String password;
 
   @Column(nullable = false, unique = false, updatable = true, length = 20)

--- a/src/main/java/com/volumeTest/volume/member/mapper/MemberMapper.java
+++ b/src/main/java/com/volumeTest/volume/member/mapper/MemberMapper.java
@@ -2,9 +2,7 @@ package com.volumeTest.volume.member.mapper;
 
 import com.volumeTest.volume.member.dto.MemberDto;
 import com.volumeTest.volume.member.entity.Member;
-import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
 public interface MemberMapper {
   // To Entity
   Member memberPostDtoToMember(MemberDto.Post memberPostDto);

--- a/src/main/java/com/volumeTest/volume/member/mapper/MemberMapper.java
+++ b/src/main/java/com/volumeTest/volume/member/mapper/MemberMapper.java
@@ -1,2 +1,22 @@
-package com.volumeTest.volume.member.mapper;public interface MemberMapper {
+package com.volumeTest.volume.member.mapper;
+
+import com.volumeTest.volume.member.dto.MemberDto;
+import com.volumeTest.volume.member.entity.Member;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface MemberMapper {
+  // To Entity
+  Member memberPostDtoToMember(MemberDto.Post memberPostDto);
+  Member memberPatchDtoToMember(MemberDto.Patch memberPatchDto);
+
+  // Login
+  MemberDto.Login memberToLoginDto(Member member);
+
+  // Check
+  MemberDto.CheckPassword checkPasswordToMember(MemberDto.CheckPassword checkPasswordDto);
+
+  // Response
+  MemberDto.MemberPostResponse memberToMemberPostResponseDto(Member member);
+  MemberDto.MemberPatchResponse memberToMemberPatchResponseDto(Member member);
 }

--- a/src/main/java/com/volumeTest/volume/member/mapper/MemberMapper.java
+++ b/src/main/java/com/volumeTest/volume/member/mapper/MemberMapper.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.member.mapper;public interface MemberMapper {
+}

--- a/src/main/java/com/volumeTest/volume/member/mapper/MemberMapperImpl.java
+++ b/src/main/java/com/volumeTest/volume/member/mapper/MemberMapperImpl.java
@@ -1,2 +1,95 @@
-package com.volumeTest.volume.member.mapper;public class MemberMapperImpl {
+package com.volumeTest.volume.member.mapper;
+
+import com.volumeTest.volume.member.dto.MemberDto;
+import com.volumeTest.volume.member.entity.Member;
+import java.time.LocalDateTime;
+import javax.annotation.processing.Generated;
+import org.springframework.stereotype.Component;
+
+@Generated(
+        value = "org.mapstruct.ap.MappingProcessor",
+        date = "2024-05-20T15:13:18+0900",
+        comments = "version: 1.5.5.Final, compiler: IncrementalProcessingEnvironment from gradle-language-java-8.7.jar, environment: Java 17.0.9 (Oracle Corporation)"
+)
+@Component
+public class MemberMapperImpl implements MemberMapper {
+
+  @Override
+  public Member memberPostDtoToMember(MemberDto.Post memberPostDto) {
+    if ( memberPostDto == null ) {
+      return null;
+    }
+
+    Member member = new Member();
+
+    return member;
+  }
+
+  @Override
+  public Member memberPatchDtoToMember(MemberDto.Patch memberPatchDto) {
+    if ( memberPatchDto == null ) {
+      return null;
+    }
+
+    Member member = new Member();
+
+    return member;
+  }
+
+  @Override
+  public MemberDto.Login memberToLoginDto(Member member) {
+    if ( member == null ) {
+      return null;
+    }
+
+    MemberDto.Login login = new MemberDto.Login();
+
+    return login;
+  }
+
+  @Override
+  public MemberDto.CheckPassword checkPasswordToMember(MemberDto.CheckPassword checkPasswordDto) {
+    if ( checkPasswordDto == null ) {
+      return null;
+    }
+    String password = null;
+    password = checkPasswordDto.getPassword();
+    MemberDto.CheckPassword checkPassword = new MemberDto.CheckPassword(password);
+
+    return checkPassword;
+  }
+
+  @Override
+  public MemberDto.MemberPostResponse memberToMemberPostResponseDto(Member member) {
+    if ( member == null ) {
+      return null;
+    }
+
+    int memberId = 0;
+    String email = null;
+    String password = null;
+    String name = null;
+    LocalDateTime createdAt = null;
+
+    MemberDto.MemberPostResponse memberPostResponse = new MemberDto.MemberPostResponse( memberId, email, password, name, createdAt );
+
+    return memberPostResponse;
+  }
+
+  @Override
+  public MemberDto.MemberPatchResponse memberToMemberPatchResponseDto(Member member) {
+    if ( member == null ) {
+      return null;
+    }
+
+    int memberId = 0;
+    String email = null;
+    String password = null;
+    String name = null;
+    LocalDateTime modifiedAt = null;
+
+    MemberDto.MemberPatchResponse memberPatchResponse = new MemberDto.MemberPatchResponse( memberId, email, password, name, modifiedAt );
+
+    return memberPatchResponse;
+  }
 }

--- a/src/main/java/com/volumeTest/volume/member/mapper/MemberMapperImpl.java
+++ b/src/main/java/com/volumeTest/volume/member/mapper/MemberMapperImpl.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.member.mapper;public class MemberMapperImpl {
+}

--- a/src/main/java/com/volumeTest/volume/member/repository/MemberRepository.java
+++ b/src/main/java/com/volumeTest/volume/member/repository/MemberRepository.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.member.repository;public interface MemberRepository {
+}

--- a/src/main/java/com/volumeTest/volume/member/repository/MemberRepository.java
+++ b/src/main/java/com/volumeTest/volume/member/repository/MemberRepository.java
@@ -1,2 +1,12 @@
-package com.volumeTest.volume.member.repository;public interface MemberRepository {
+package com.volumeTest.volume.member.repository;
+
+import com.volumeTest.volume.member.Entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+  Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/volumeTest/volume/member/repository/MemberRepository.java
+++ b/src/main/java/com/volumeTest/volume/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
 package com.volumeTest.volume.member.repository;
 
-import com.volumeTest.volume.member.Entity.Member;
+import com.volumeTest.volume.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/volumeTest/volume/member/service/MemberService.java
+++ b/src/main/java/com/volumeTest/volume/member/service/MemberService.java
@@ -1,2 +1,21 @@
-package com.volumeTest.volume.member.service;public interface MemberService {
+package com.volumeTest.volume.member.service;
+
+import com.volumeTest.volume.member.Entity.Member;
+
+public interface MemberService {
+
+    // 회원 생성
+    Member createMember(Member member);
+
+    // 회원 조회
+    Member findMemberByEmail(String email);
+
+    // 회원 수정
+    Member updateMember(Member member, String password);
+
+    // 회원 비밀번호 변경
+    Member updateMemberPassword(Member member, String password);
+
+    // 회원 탈퇴
+    void deleteMember(Member member, String password);
 }

--- a/src/main/java/com/volumeTest/volume/member/service/MemberService.java
+++ b/src/main/java/com/volumeTest/volume/member/service/MemberService.java
@@ -11,7 +11,7 @@ public interface MemberService {
     Member findMemberByEmail(String email);
 
     // 회원 수정
-    Member updateMember(Member member, String password);
+    Member updateMember(Member member, String name, String password);
 
     // 회원 비밀번호 변경
     Member updateMemberPassword(Member member, String password);

--- a/src/main/java/com/volumeTest/volume/member/service/MemberService.java
+++ b/src/main/java/com/volumeTest/volume/member/service/MemberService.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.member.service;public interface MemberService {
+}

--- a/src/main/java/com/volumeTest/volume/member/service/MemberService.java
+++ b/src/main/java/com/volumeTest/volume/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.volumeTest.volume.member.service;
 
-import com.volumeTest.volume.member.Entity.Member;
+import com.volumeTest.volume.member.entity.Member;
 
 public interface MemberService {
 

--- a/src/main/java/com/volumeTest/volume/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/volumeTest/volume/member/service/MemberServiceImpl.java
@@ -1,0 +1,2 @@
+package com.volumeTest.volume.member.service;public class MemberServiceImpl {
+}

--- a/src/main/java/com/volumeTest/volume/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/volumeTest/volume/member/service/MemberServiceImpl.java
@@ -1,7 +1,7 @@
 package com.volumeTest.volume.member.service;
 
 import com.volumeTest.volume.common.exception.codeEnum.ExceptionCode;
-import com.volumeTest.volume.member.Entity.Member;
+import com.volumeTest.volume.member.entity.Member;
 import com.volumeTest.volume.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/volumeTest/volume/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/volumeTest/volume/member/service/MemberServiceImpl.java
@@ -35,14 +35,14 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
-  public Member updateMember(Member member, String password) {
+  public Member updateMember(Member member, String name, String password) {
     // 회원 조회
     Member findMember = findVerifyMemberByEmail(member.getEmail());
 
     checkPassword(findMember, password);
 
     // 변경할 정보 저장
-    findMember.setName(member.getName());
+    findMember.setName(name);
 
     // 변경된 정보 저장
     Member updatedMember = memberRepository.save(findMember);
@@ -55,13 +55,13 @@ public class MemberServiceImpl implements MemberService {
   public Member updateMemberPassword(Member member, String password) {
     Member findMember = findVerifyMemberByEmail(member.getEmail());
 
-    // 변경할 비밀번호 암호화
-    String encryptedPassword = passwordEncoder.encode(password);
-
     // 새로운 비밀번호와 이전 비밀번호가 같으면 변경하지 않음
-    if (passwordEncoder.matches(findMember.getPassword(), encryptedPassword)) {
+    if (passwordEncoder.matches(password, findMember.getPassword())) { // 평문 비밀번호와 암호화된 비밀번호 비교
       throw new RuntimeException(ExceptionCode.MEMBER_PASSWORD_NOT_CHANGE.getMessage());
     }
+
+    // 변경할 비밀번호 암호화
+    String encryptedPassword = passwordEncoder.encode(password);
 
     // 변경할 암호화된 비밀번호 저장
     findMember.setPassword(encryptedPassword);
@@ -71,6 +71,7 @@ public class MemberServiceImpl implements MemberService {
 
     return updatedMember;
   }
+
 
   @Override
   public void deleteMember(Member member, String password) {
@@ -97,10 +98,8 @@ public class MemberServiceImpl implements MemberService {
   private Boolean checkPassword(Member member, String password) {
     // 회원의 비밀번호 추출
     String memberPassword = member.getPassword();
-    // 입력받은 비밀번호 암호화
-    String encryptedPassword = passwordEncoder.encode(password);
     // 비밀번호가 일치하지 않으면 예외 발생
-    if(!passwordEncoder.matches(memberPassword, encryptedPassword)) {
+    if(!passwordEncoder.matches(password, memberPassword)) {
       throw new RuntimeException(ExceptionCode.MEMBER_PASSWORD_MISMATCH.getMessage());
     }
     // 비밀번호가 일치하면 true 반환

--- a/src/main/java/com/volumeTest/volume/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/volumeTest/volume/member/service/MemberServiceImpl.java
@@ -1,2 +1,109 @@
-package com.volumeTest.volume.member.service;public class MemberServiceImpl {
+package com.volumeTest.volume.member.service;
+
+import com.volumeTest.volume.common.exception.codeEnum.ExceptionCode;
+import com.volumeTest.volume.member.Entity.Member;
+import com.volumeTest.volume.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+  private final MemberRepository memberRepository;
+  private final BCryptPasswordEncoder passwordEncoder;
+
+  @Override
+  public Member createMember(Member member) {
+    verifyExistsEmail(member.getEmail());
+    // 비밀번호 암호화
+    String encryptedPassword = passwordEncoder.encode(member.getPassword());
+    member.setPassword(encryptedPassword);
+
+    Member savedMember = memberRepository.save(member);
+    return savedMember;
+  }
+
+  @Override
+  public Member findMemberByEmail(String email) {
+    return findVerifyMemberByEmail(email);
+  }
+
+  @Override
+  public Member updateMember(Member member, String password) {
+    // 회원 조회
+    Member findMember = findVerifyMemberByEmail(member.getEmail());
+
+    checkPassword(findMember, password);
+
+    // 변경할 정보 저장
+    findMember.setName(member.getName());
+
+    // 변경된 정보 저장
+    Member updatedMember = memberRepository.save(findMember);
+
+    log.info("{}님의 정보가 수정되었습니다. 수정된 정보: 이름={}, 이메일={}", findMember.getName(), updatedMember.getName(), updatedMember.getEmail());
+    return updatedMember;
+  }
+
+  @Override
+  public Member updateMemberPassword(Member member, String password) {
+    Member findMember = findVerifyMemberByEmail(member.getEmail());
+
+    // 변경할 비밀번호 암호화
+    String encryptedPassword = passwordEncoder.encode(password);
+
+    // 새로운 비밀번호와 이전 비밀번호가 같으면 변경하지 않음
+    if (passwordEncoder.matches(findMember.getPassword(), encryptedPassword)) {
+      throw new RuntimeException(ExceptionCode.MEMBER_PASSWORD_NOT_CHANGE.getMessage());
+    }
+
+    // 변경할 암호화된 비밀번호 저장
+    findMember.setPassword(encryptedPassword);
+
+    // 변경된 정보 저장
+    Member updatedMember = memberRepository.save(findMember);
+
+    return updatedMember;
+  }
+
+  @Override
+  public void deleteMember(Member member, String password) {
+    // 패스워드로 검증
+    checkPassword(member, password);
+    memberRepository.delete(member);
+  }
+
+  // Verify
+  private void verifyExistsEmail(String email) {
+    memberRepository.findByEmail(email)
+            .ifPresent(member -> {
+              throw new RuntimeException(ExceptionCode.MEMBER_EMAIL_EXISTS.getMessage());
+            });
+  }
+
+  private Member findVerifyMemberByEmail(String email) {
+    return memberRepository.findByEmail(email)
+            .orElseThrow(() -> {
+              throw new RuntimeException(ExceptionCode.MEMBER_NOT_FOUND.getMessage());
+            });
+  }
+
+  private Boolean checkPassword(Member member, String password) {
+    // 회원의 비밀번호 추출
+    String memberPassword = member.getPassword();
+    // 입력받은 비밀번호 암호화
+    String encryptedPassword = passwordEncoder.encode(password);
+    // 비밀번호가 일치하지 않으면 예외 발생
+    if(!passwordEncoder.matches(memberPassword, encryptedPassword)) {
+      throw new RuntimeException(ExceptionCode.MEMBER_PASSWORD_MISMATCH.getMessage());
+    }
+    // 비밀번호가 일치하면 true 반환
+    return true;
+  }
 }

--- a/src/main/java/com/volumeTest/volume/security/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/volumeTest/volume/security/config/PasswordEncoderConfig.java
@@ -1,0 +1,13 @@
+package com.volumeTest.volume.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+  @Bean
+  public BCryptPasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/test/java/com/volumeTest/volume/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/volumeTest/volume/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,117 @@
+package com.volumeTest.volume.member.repository;
+
+import com.volumeTest.volume.member.entity.Member;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@Transactional
+@DataJpaTest
+class MemberRepositoryTest {
+
+  @Autowired
+  private MemberRepository memberRepository;
+
+  Member kim;
+
+  @BeforeEach
+  void setUp() {
+    kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    memberRepository.save(kim);
+  }
+
+//  @AfterEach
+//  void tearDown() {
+//    memberRepository.deleteAll();
+//  }
+
+  @Test
+  @DisplayName("회원 생성 시 이메일 중복 체크탐지 테스트")
+  void createMemberEmailCheck() {
+    // given
+    Member hong = new Member(2, "test@gmail.com", "a654321!#", "홍길동");
+
+    // when & then
+    assertThrows(Exception.class, () -> memberRepository.save(hong));
+  }
+
+  @Test
+  @DisplayName("회원 생성 시 패스워드 길이 초과 테스트")
+  void createMemberPasswordLengthValidation() {
+    // given
+    Member hong = new Member(2, "hong@gmail.com", "1234567890123456789901", "홍길동");
+
+    // when & then
+    assertThrows(Exception.class, () -> memberRepository.save(hong));
+  }
+
+  @Test
+  @DisplayName("회원 생성 시 이메일 길이 초과 테스트")
+  void createMemberEmailLengthValidation() {
+    // given
+    Member hong = new Member(2, "hong@gmailandkakakoandnaverzzzhaha.com", "a123456!#", "홍길동");
+
+    // when & then
+    assertThrows(Exception.class, () -> memberRepository.save(hong));
+  }
+
+  @Test
+  @DisplayName("회원 생성 시 이름 길이 초과 테스트")
+  void createMemberNameLengthValidation() {
+    // given
+    Member hong = new Member(2, "hong@gmail.com", "a123456!#", "홍길동그라미어캣타워싱턴테이블레이저수지역삼성전자전거위로이킴민재");
+
+    // when & then
+    assertThrows(Exception.class, () -> memberRepository.save(hong));
+  }
+
+  @Test
+  @DisplayName("NULL 허용 방지 테스트")
+  void createMemberNullValidation() {
+    // given
+    Member hong = new Member(2, null, "a123456!#", "홍길동");
+    Member park = new Member(3, "park@gmail.com", null, "박철준");
+    Member lee = new Member(4, "lee@gmail.com", "a123456!#", null);
+
+    // when & then
+    assertThrows(Exception.class, () -> memberRepository.save(hong));
+    assertThrows(Exception.class, () -> memberRepository.save(park));
+    assertThrows(Exception.class, () -> memberRepository.save(lee));
+  }
+
+  @Test
+  @DisplayName("이메일로 회원 조회 성공 테스트")
+  void findByEmail() {
+    // given
+    String email = "test@gmail.com";
+
+    // when
+    Member member = memberRepository.findByEmail(email).orElse(null);
+    log.info("member.getEmail() = {}", member.getEmail());
+
+    // then
+    assertNotNull(member);
+    assertEquals(member.getEmail(), kim.getEmail());
+  }
+
+  @Test
+  @DisplayName("이메일로 회원 조회 실패 테스트")
+  void findByEmailFail() {
+    // given
+    String email = "hong@gmail.com";
+
+    // when
+    Member member = memberRepository.findByEmail(email).orElse(null);
+
+    // then
+    assertNull(member);
+    }
+}

--- a/src/test/java/com/volumeTest/volume/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/volumeTest/volume/member/service/MemberServiceImplTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class MemberServiceImplTest {
+  
+}

--- a/src/test/java/com/volumeTest/volume/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/volumeTest/volume/member/service/MemberServiceImplTest.java
@@ -1,4 +1,106 @@
+package com.volumeTest.volume.member.service;
+
+import com.volumeTest.volume.member.entity.Member;
+import com.volumeTest.volume.member.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@Transactional
+@SpringBootTest
 class MemberServiceImplTest {
-  
+
+  @Autowired
+  private MemberService memberService;
+
+  @Autowired
+  private BCryptPasswordEncoder passwordEncoder;
+
+  @Test
+  @DisplayName("회원 생성 테스트")
+  void createMember() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    Member member = memberService.createMember(kim);
+    // when & then
+    assertThat(member.getMemberId()).isEqualTo(kim.getMemberId());
+    assertThat(member.getEmail()).isEqualTo(kim.getEmail());
+    assertThat(member.getPassword()).isEqualTo(kim.getPassword());
+    assertThat(member.getName()).isEqualTo(kim.getName());
+  }
+
+  @Test
+  @DisplayName("회원 이메일로 조회 테스트")
+  void findMemberByEmail() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    Member member = memberService.createMember(kim);
+
+    // when
+    Member findMember = memberService.findMemberByEmail(member.getEmail());
+
+    // then
+    assertThat(findMember.getMemberId()).isEqualTo(member.getMemberId());
+    assertThat(findMember.getEmail()).isEqualTo(member.getEmail());
+    assertThat(findMember.getPassword()).isEqualTo(member.getPassword());
+    assertThat(findMember.getName()).isEqualTo(member.getName());
+  }
+
+  @Test
+  @DisplayName("회원 정보 수정 테스트")
+  void updateMember() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    Member member = memberService.createMember(kim);
+
+    // when
+    Member updateMember = memberService.updateMember(member, "김자바", "a123456!#");
+
+    // then
+    assertThat(updateMember.getName()).isEqualTo("김자바");
+    assertThat(memberService.findMemberByEmail(member.getEmail()).getName()).isEqualTo("김자바");
+  }
+
+  @Test
+  @DisplayName("회원 비밀번호 수정 테스트")
+  void updateMemberPassword() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    Member member = memberService.createMember(kim);
+
+    // when
+    Member updateMember = memberService.updateMemberPassword(member, "a654321!#");
+    Member findMember = memberService.findMemberByEmail(member.getEmail());
+
+    // then
+    assertTrue(passwordEncoder.matches("a654321!#", findMember.getPassword())); // 새로운 비밀번호 일치 확인
+  }
+
+
+
+  @Test
+  @DisplayName("회원 탈퇴 테스트")
+  void deleteMember() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    Member member = memberService.createMember(kim);
+
+    // when
+    memberService.deleteMember(member, "a123456!#");
+
+    // then
+    assertThrows(Exception.class, () -> memberService.findMemberByEmail(member.getEmail()));
+  }
 }

--- a/src/test/java/com/volumeTest/volume/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/volumeTest/volume/member/service/MemberServiceImplTest.java
@@ -42,6 +42,17 @@ class MemberServiceImplTest {
   }
 
   @Test
+  @DisplayName("중복된 이메일로 회원 가입 시 예외 발생 테스트")
+  void createMemberWithDuplicateEmail() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    memberService.createMember(kim);
+
+    // when & then
+    assertThrows(Exception.class, () -> memberService.createMember(kim)); // 이미 존재하는 이메일로 가입 시도
+  }
+
+  @Test
   @DisplayName("회원 이메일로 조회 테스트")
   void findMemberByEmail() {
     // given
@@ -56,6 +67,16 @@ class MemberServiceImplTest {
     assertThat(findMember.getEmail()).isEqualTo(member.getEmail());
     assertThat(findMember.getPassword()).isEqualTo(member.getPassword());
     assertThat(findMember.getName()).isEqualTo(member.getName());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 이메일로 회원 조회 시 예외 발생")
+  void findMemberByEmailFail() {
+    // given
+    String invalidEmail = "invalid@email.com";
+
+    // when & then
+    assertThrows(Exception.class, () -> memberService.findMemberByEmail(invalidEmail));
   }
 
   @Test
@@ -74,6 +95,17 @@ class MemberServiceImplTest {
   }
 
   @Test
+  @DisplayName("잘못된 비밀번호로 회원 정보 수정 시 예외 발생 테스트")
+  void updateMemberWithWrongPassword() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    Member member = memberService.createMember(kim);
+
+    // when & then
+    assertThrows(Exception.class, () -> memberService.updateMember(member, "김자바", "wrongPassword"));
+  }
+
+  @Test
   @DisplayName("회원 비밀번호 수정 테스트")
   void updateMemberPassword() {
     // given
@@ -88,7 +120,16 @@ class MemberServiceImplTest {
     assertTrue(passwordEncoder.matches("a654321!#", findMember.getPassword())); // 새로운 비밀번호 일치 확인
   }
 
+  @Test
+  @DisplayName("동일한 비밀번호로 비밀번호 변경 시도 시 예외 발생 테스트")
+  void updateMemberPasswordWithSamePassword() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    Member member = memberService.createMember(kim);
 
+    // when & then
+    assertThrows(Exception.class, () -> memberService.updateMemberPassword(member, "a123456!#"));
+  }
 
   @Test
   @DisplayName("회원 탈퇴 테스트")
@@ -102,5 +143,16 @@ class MemberServiceImplTest {
 
     // then
     assertThrows(Exception.class, () -> memberService.findMemberByEmail(member.getEmail()));
+  }
+
+  @Test
+  @DisplayName("잘못된 비밀번호로 회원 탈퇴 시도 시 예외 발생 테스트")
+  void deleteMemberWithWrongPassword() {
+    // given
+    Member kim = new Member(1, "test@gmail.com", "a123456!#", "김테스트");
+    Member member = memberService.createMember(kim);
+
+    // when & then
+    assertThrows(Exception.class, () -> memberService.deleteMember(member, "wrongPassword"));
   }
 }


### PR DESCRIPTION
❗️ 현재 Mapper 인터페이스에서 Build했을때 구현체가 이상하게 생성되는 이슈가 있어 수정중에 있습니다. ~~(24.5.20)~~
- 직접 Mapper구현체도 구현해봤는데 인터페이스에서 확장해오는 중 원인 모를 이슈가 발생 중에 있습니다. 수정 후 다시 한번 알려드릴 수 있도록 하겠습니다.
- 🎉 직접 구현한 Mapper 구현체와 빌드과정에서 자동 생성되는 Mapper 구현체와의 충돌이 발생한 문제였습니다.(`해결 완료`, 24.5.20) 

🌟 추가
- 회원 Entity, Dto, Repository 구현
- 유효성검사를 위한 Custom Validator 애너테이션 생성
- 회원관련 Service레벨 Interface 및 구현체 생성 및 로직 구현
- controller 구현  -> API URI 수정필요(임시로 수정해봤슴다 일단)
- Repository Level TestCode 추가.(더 필요한 테스트 있어보이시면 리뷰 달아주세요)
- Service Level TestCode 추가.

💡기타 추가 사항
- 생성 및 수정관련 시간 자동생성을 위한 Auditable 추가
- 예외처리 관련 메세지를 관리하기위해 ExceptionCode Enum 추가
- 비밀번호 암호화를 위한 환경설정클래스 생성 후 Salt값 활용을 위한 BCryptPasswordEncoder 주입

💡 수정 사항
- Mapper를 위한 MapStruct 버전 업데이트(1.5.3 -> 1.5.5)

🐥 개선할 사항
- 테스트코드 추가 예정(진행중)